### PR TITLE
RCTBridge include

### DIFF
--- a/RNAppInfo/RNAppInfo.m
+++ b/RNAppInfo/RNAppInfo.m
@@ -5,11 +5,6 @@
 //
 
 #import "RNAppInfo.h"
-#if __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import <React/RCTBridge.h>
-#endif
 
 @implementation RNAppInfo
 RCT_EXPORT_MODULE();

--- a/RNAppInfo/RNAppInfo.m
+++ b/RNAppInfo/RNAppInfo.m
@@ -5,6 +5,13 @@
 //
 
 #import "RNAppInfo.h"
+#ifndef RCT_EXPORT_METHOD
+#if __has_include("RCTBridge.h")
+#import "RCTBridge.h"
+#else
+#import <React/RCTBridge.h>
+#endif
+#endif
 
 @implementation RNAppInfo
 RCT_EXPORT_MODULE();


### PR DESCRIPTION
Basically, the build fails because of the RCTBridge.h include in this file. Failure report points to RCTBridgeModule.h being included more than once. It's also included in RCTBridge.h. 